### PR TITLE
Hora del sistema

### DIFF
--- a/citas_admin/blueprints/cit_citas/templates/cit_citas/new.jinja2
+++ b/citas_admin/blueprints/cit_citas/templates/cit_citas/new.jinja2
@@ -35,7 +35,17 @@
         <select class="form-select" aria-label="servicios" name="serviciosSelect" id="serviciosSelect" onchange="listar_horarios();">
         </select>
 
-        <label class="form-label mt-3" for="horarios_list">Horarios disponibles:</label>
+        <div class="row">
+            <label class="form-label mt-3" for="horarios_list">Horarios disponibles:</label>
+        </div>
+        <div class="row">
+            <div class="col-md-3">
+                <label class="form-label" for="hora_actual">Hora Actual del Servidor:</label>
+            </div>
+            <div class="col-md-9 text-start">
+                {{ hora_actual }}
+            </div>
+        </div>
         <ul class="list-group" id="horarios_list" name="horarios_list">
         {% for horario in horarios %}
             <li class="list-group-item">

--- a/citas_admin/blueprints/cit_citas/views.py
+++ b/citas_admin/blueprints/cit_citas/views.py
@@ -507,6 +507,7 @@ def new(cit_cliente_id):
         cit_cliente=cliente,
         oficinas=oficinas,
         form=form,
+        hora_actual=datetime.now().strftime("%H:%M %p"),
     )
 
 


### PR DESCRIPTION
En cita inmediata muestra el horario del servidor, ya que se sospecha la hora se está adelantando y por esa razón no se ven los horarios completos para agendar una nueva cita.